### PR TITLE
Fix wally references error.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true
+  "files.trimFinalNewlines": true,
+  "robloxLsp.workspace.rojoProjectFile": "dev"
 }

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Aftman, a cross-platform toolchain manager.
+# For more information, see https://github.com/LPGhatguy/aftman
+
+# To add a new tool, add an entry to this table.
+[tools]
+rojo = "rojo-rbx/rojo@7.3.0"
+# rojo = "rojo-rbx/rojo@6.2.0"

--- a/default.project.json
+++ b/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "FirebaseLuau",
+  "name": "firebase",
   "tree": {
     "$path": "src"
   }

--- a/dev.project.json
+++ b/dev.project.json
@@ -2,22 +2,17 @@
   "name": "FirebaseLuau - Dev",
   "tree": {
     "$className": "DataModel",
-
-    "ServerStorage": {
-      "$className": "ServerStorage",
-
-      "FirebaseLuau": { "$path": "." }
-    },
-
     "ReplicatedStorage": {
       "$className": "ReplicatedStorage",
-
-      "Packages": { "$path": "Packages" }
+      "Packages": {
+        "$path": "Packages",
+        "FirebaseLuau": {
+          "$path": "."
+        }
+      }
     },
-
     "HttpService": {
       "$className": "HttpService",
-
       "$properties": {
         "HttpEnabled": true
       }

--- a/src/Http.lua
+++ b/src/Http.lua
@@ -1,7 +1,7 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local HttpService = game:GetService("HttpService")
 
-local Promise = require(ReplicatedStorage.Packages.Promise)
+local Promise = require(script.Parent.Parent.Promise)
 
 local BASE_URLs = {
     Firestore = function(app)

--- a/src/Services/Authentication/init.lua
+++ b/src/Services/Authentication/init.lua
@@ -1,6 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Promise = require(ReplicatedStorage.Packages.Promise)
+local Promise = require(script.Parent.Parent.Parent.Promise)
 local Auth = require(script.Auth)
 
 local Authentication = {}

--- a/src/Services/Firestore/Collection/DocumentList.lua
+++ b/src/Services/Firestore/Collection/DocumentList.lua
@@ -1,6 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Promise = require(ReplicatedStorage.Packages.Promise)
+local Promise = require(script.Parent.Parent.Parent.Parent.Parent.Promise)
 local Document = require(script.Parent.Parent.Document)
 
 --[=[

--- a/src/Services/Firestore/Document.lua
+++ b/src/Services/Firestore/Document.lua
@@ -1,6 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Promise = require(ReplicatedStorage.Packages.Promise)
+local Promise = require(script.Parent.Parent.Parent.Parent.Promise)
 local Parser = require(script.Parent.Parser)
 local TableUtils = require(script.Parent.Parent.TableUtils)
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
-name = "raphtalia/firebase"
-description = "Roblox Firebase API"
-version = "1.0.6"
+name = "ldhongen1990/firebase"
+description = "Forked of original project https://github.com/raphtalia/FirebaseLuau to fix wally errors. My forked repo is over here: https://github.com/ldhongen1990/FirebaseLuau"  
+version = "1.0.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "server"


### PR DESCRIPTION
A couple of file references the Promise library directly with absolute pathing:

`local Promise = require(ReplicatedStorage.Packages.Promise)
`

This will work if the consumer project has a Promise dependencies but **will not work if the project only have Firebase dependencies.**

I have provided the fix by updating the path to a relative path.
Eg: `local Promise = require(script.Parent.Parent.Promise)`

I have also updated the `dev.project.json` file so that they reside inside ReplicatedStorage (for development testing purposes only, in production the library will still be installed to ServerPackages as expected).
This is so that relative references to the Promise library will still be a valid path during development.

**I am not sure if the original repo is still being maintained so I have published a new wally package so that I can use the fix immediately.**

**You will have to update `wally.toml` to match back to the wally package at https://wally.run/package/raphtalia/firebase** if you do accept this pull request.